### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,15 +112,15 @@
         </pluginRepository>
     </pluginRepositories>
     <build>
- 	  <plugins>
+ 	 <plugins>
   	   <plugin>
-    	 <groupId>org.apache.maven.plugins</groupId>
-      	 <artifactId>maven-javadoc-plugin</artifactId>
-      	 <configuration>
+    	     <groupId>org.apache.maven.plugins</groupId>
+      	     <artifactId>maven-javadoc-plugin</artifactId>
+      	     <configuration>
          	<additionalparam>-Xdoclint:none</additionalparam>
-      	 </configuration>
-    	 </plugin>
+      	     </configuration>
+    	   </plugin>
   	 </plugins>
-	</build>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
       <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -111,5 +111,16 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+     <build>
+ 	  <plugins>
+  	   <plugin>
+    	 <groupId>org.apache.maven.plugins</groupId>
+      	 <artifactId>maven-javadoc-plugin</artifactId>
+      	 <configuration>
+         	<additionalparam>-Xdoclint:none</additionalparam>
+      	 </configuration>
+    	 </plugin>
+  	 </plugins>
+	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-     <build>
+    <build>
  	  <plugins>
   	   <plugin>
     	 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Disables DocLint, which is enabled on Java8 by default and causes build and release errors.