### PR TITLE
Add "Force Update" Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This plugin can be called as `marathon(...)` within [a pipeline job](https://git
 ```
 marathon(
     url: 'http://marathon-instance',
+    forceUpdate: false,
     appid: 'someid',
     docker: 'mesosphere/jenkins-dev')
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         </developer>
     </developers>
     <properties>
-        <marathon.client.version>0.2.1</marathon.client.version>
+        <marathon.client.version>0.3.0</marathon.client.version>
         <pipeline.version>1.13</pipeline.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
@@ -51,6 +51,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     private       String              docker;
     private       String              filename;
     private       String              credentialsId;
+    private       boolean             forceUpdate;
 
     @DataBoundConstructor
     public MarathonRecorder(final String url) {
@@ -93,15 +94,6 @@ public class MarathonRecorder extends Recorder implements AppConfig {
          * This should be run before the build is finalized.
          */
         return false;
-    }
-
-    public String getCredentialsId() {
-        return this.credentialsId;
-    }
-
-    @DataBoundSetter
-    public void setCredentialsId(final String credentialsId) {
-        this.credentialsId = credentialsId;
     }
 
     /**
@@ -185,13 +177,22 @@ public class MarathonRecorder extends Recorder implements AppConfig {
         return url;
     }
 
+    @Override
+    public boolean getForceUpdate() {
+        return forceUpdate;
+    }
+
     public String getDocker() {
         return docker;
     }
 
+    public String getCredentialsId() {
+        return this.credentialsId;
+    }
+
     @DataBoundSetter
-    public void setDocker(@Nonnull final String docker) {
-        this.docker = docker;
+    public void setCredentialsId(final String credentialsId) {
+        this.credentialsId = credentialsId;
     }
 
     public List<MarathonUri> getUris() {
@@ -210,6 +211,25 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     @DataBoundSetter
     public void setLabels(final List<MarathonLabel> labels) {
         this.labels = labels;
+    }
+
+    @DataBoundSetter
+    public void setDocker(@Nonnull final String docker) {
+        this.docker = docker;
+    }
+
+    /**
+     * Used by jelly or stapler to determine checkbox state.
+     *
+     * @return True if Force Update is enabled; False otherwise.
+     */
+    public boolean isForceUpdate() {
+        return getForceUpdate();
+    }
+
+    @DataBoundSetter
+    public void setForceUpdate(final boolean forceUpdate) {
+        this.forceUpdate = forceUpdate;
     }
 
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
@@ -30,6 +30,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     private       String              docker;
     private       String              filename;
     private       String              credentialsId;
+    private       boolean             forceUpdate;
 
     @DataBoundConstructor
     public MarathonStep(final String url) {
@@ -45,6 +46,16 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
 
     public String getUrl() {
         return url;
+    }
+
+    @Override
+    public boolean getForceUpdate() {
+        return forceUpdate;
+    }
+
+    @DataBoundSetter
+    public void setForceUpdate(final boolean forceUpdate) {
+        this.forceUpdate = forceUpdate;
     }
 
     public String getDocker() {

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
@@ -68,7 +68,7 @@ public class MarathonBuilderImpl extends MarathonBuilder {
                     usercreds == null ? MarathonClient.getInstance(config.getUrl()) :
                             MarathonClient.getInstanceWithBasicAuth(config.getUrl(), usercreds.getUsername(), usercreds.getPassword().getPlainText()) :
                     MarathonClient.getInstanceWithTokenAuth(config.getUrl(), creds.getSecret().getPlainText());
-            marathon.updateApp(app.getId(), app);   // uses PUT
+            marathon.updateApp(app.getId(), app, config.getForceUpdate());   // uses PUT
         }
         return this;
     }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
@@ -21,6 +21,16 @@ public interface AppConfig {
     String getUrl();
 
     /**
+     * Get the value of whether the Marathon update should be forced. If set to
+     * True, an in-progress deployment of this application will be canceled in
+     * favor of this update. If set to False, an error will occur because the
+     * application has a deployment in progress.
+     *
+     * @return whether to force the Marathon application update
+     */
+    boolean getForceUpdate();
+
+    /**
      * Get the configured docker image name.
      *
      * @return Docker image name

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
@@ -4,6 +4,10 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry title="${%Force Update}" field="forceUpdate">
+        <f:checkbox/>
+    </f:entry>
+
     <f:entry field="credentialsId" title="${%Authentication Credentials}">
         <c:select/>
     </f:entry>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-forceUpdate.html
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-forceUpdate.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        This parameter decides how to handle updating a Marathon application that has an active deployment.
+    </p>
+    <p>
+        If this is set to <code>true</code> (checked), then a new deployment will be forced and the current deployment
+        canceled. If this is set to <code>false</code> (unchecked), then this plugin will attempt to update the Marathon
+        application every couple of seconds until a timeout is reached. If the active deployment does not complete within
+        the time frame, then an error will be returned and the job marked as failed.
+    </p>
+    <p>
+        More information can be found on the
+        <a href="https://mesosphere.github.io/marathon/docs/rest-api.html#put-v2-apps-appid" target="_blank">
+        Marathon REST API</a> documentation page.
+    </p>
+</div>


### PR DESCRIPTION
Add the option to force the Marathon application update, even if a deployment is active for the application.

If set, this will cancel the current deployment and immediately start deploying the new build. If this is not set, then the behavior stays the same as before this was introduced: the plugin will loop for a set timeout waiting on the current deployment to finish.
