### PR TITLE
Added Snippet Generator config for MarathonStep

### DIFF
--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
@@ -1,15 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="url" title="${%MarathonURL Marathon URL}">
+    <f:entry field="url" title="${%Marathon URL}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="forceUpdate" title="${%ForceUpdate Force Update}">
+    <f:entry field="forceUpdate" title="${%Force Update}">
         <f:checkbox name="forceUpdate" />
     </f:entry>
-    <f:entry field="appid" title="${%AppId App ID}">
+    <f:entry field="appid" title="${%App ID}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="docker" title="${%Docker Docker}">
+    <f:entry field="docker" title="${%Docker}">
         <f:textbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="url" title="Marathon URL">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="forceUpdate" title="Force Update">
+        <f:checkbox name="forceUpdate" />
+    </f:entry>
+    <f:entry field="appid" title="App ID">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="docker" title="Docker">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
@@ -1,15 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="url" title="Marathon URL">
+    <f:entry field="url" title="${%MarathonURL Marathon URL}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="forceUpdate" title="Force Update">
+    <f:entry field="forceUpdate" title="${%ForceUpdate Force Update}">
         <f:checkbox name="forceUpdate" />
     </f:entry>
-    <f:entry field="appid" title="App ID">
+    <f:entry field="appid" title="${%AppId App ID}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="docker" title="Docker">
+    <f:entry field="docker" title="${%Docker Docker}">
         <f:textbox/>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
Just added a config.jelly file to enable the Snippet Generator to generate a Groovy line with URL/Force Update/App Id/Docker args.
Generates Groovy as follows :
`marathon appid: 'myappid', docker: 'mydocker', forceUpdate: true, url: 'mymarathonurl'`