### PR TITLE
Empty parent.relativePath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.19</version>
+        <relativePath></relativePath>
     </parent>
     <groupId>com.mesosphere.velocity</groupId>
     <artifactId>marathon</artifactId>


### PR DESCRIPTION
Attempt to fix an error about pom resolution due to invalid relativePath.