### PR TITLE
Bump `marathon-client` version to `0.6.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.mesosphere.velocity</groupId>
     <artifactId>marathon</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6.0</version>
     <packaging>hpi</packaging>
 
     <name>Marathon Deployment</name>
@@ -60,7 +60,7 @@
         <credentials.version>1.22</credentials.version>
         <http.version>4.5.1</http.version>
         <junit.version>4.11</junit.version>
-        <marathon.client.version>0.5.0</marathon.client.version>
+        <marathon.client.version>0.6.0</marathon.client.version>
         <mockito.version>1.10.19</mockito.version>
         <mockweb-version>3.5.0</mockweb-version>
         <pipeline.version>1.13</pipeline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.mesosphere.velocity</groupId>
     <artifactId>marathon</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Marathon Deployment</name>

--- a/src/test/resources/com/mesosphere/velocity/marathon/allfields.json
+++ b/src/test/resources/com/mesosphere/velocity/marathon/allfields.json
@@ -25,28 +25,27 @@
     "docker": {
       "forcePullImage": false,
       "image": "mesosphere:marathon/latest",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "name",
           "value": "kdc"
         }
       ],
-      "portMappings": [
-        {
-          "containerPort": 80,
-          "hostPort": 0,
-          "protocol": "tcp",
-          "servicePort": 10019,
-          "name": "http",
-          "labels": {
-            "vip": "192.168.0.1:80"
-          }
-        }
-      ],
       "privileged": false
     },
     "type": "DOCKER",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp",
+        "servicePort": 10019,
+        "name": "http",
+        "labels": {
+          "vip": "192.168.0.1:80"
+        }
+      }
+    ],
     "volumes": [
       {
         "containerPath": "/docker_storage",
@@ -55,6 +54,12 @@
       }
     ]
   },
+  "networks": [
+    {
+      "mode": "container/bridge",
+      "labels": {}
+    }
+  ],
   "dependencies": [
     "/prod/group"
   ],


### PR DESCRIPTION
`0.6.0` updates the `container` API schema: https://github.com/mesosphere/marathon-client/tree/v0.6.0