### PR TITLE
Let Jenkins wait for deployment step is finished or timedout

### DIFF
--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
@@ -56,33 +56,35 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     private       String              filename;
     private       String              credentialsId;
     private       boolean             forceUpdate;
+    private long timeout;
 
     @DataBoundConstructor
-    public MarathonRecorder(final String url) {
+    public MarathonRecorder(String url) {
         this.url = MarathonBuilderUtils.rmSlashFromUrl(url);
 
-        this.uris = new ArrayList<MarathonUri>(5);
-        this.labels = new ArrayList<MarathonLabel>(5);
-        this.env = new ArrayList<MarathonVars>(5);
+        this.uris = new ArrayList<>(5);
+        this.labels = new ArrayList<>(5);
+        this.env = new ArrayList<>(5);
     }
 
     public String getAppid() {
-        return appid;
+        return this.appid;
     }
 
     @DataBoundSetter
-    public void setAppid(@Nonnull final String appid) {
+    public void setAppid(@Nonnull String appid) {
         this.appid = appid;
     }
 
     public String getFilename() {
-        return filename;
+        return this.filename;
     }
 
     @DataBoundSetter
-    public void setFilename(@Nonnull final String filename) {
-        if (filename.trim().length() > 0)
+    public void setFilename(@Nonnull String filename) {
+        if (filename.trim().length() > 0) {
             this.filename = filename;
+        }
     }
 
     @Override
@@ -108,21 +110,21 @@ public class MarathonRecorder extends Recorder implements AppConfig {
      * @param logger a build's logger
      * @param text   message to log
      */
-    private void log(final PrintStream logger, final String text) {
+    private void log(PrintStream logger, String text) {
         logger.println("[Marathon] " + text);
     }
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-        final boolean     buildSucceed = build.getResult() == null || build.getResult() == Result.SUCCESS;
-        final EnvVars     envVars      = build.getEnvironment(listener);
-        final PrintStream logger       = listener.getLogger();
+        boolean buildSucceed = build.getResult() == null || build.getResult() == Result.SUCCESS;
+        EnvVars envVars = build.getEnvironment(listener);
+        PrintStream logger = listener.getLogger();
         envVars.overrideAll(build.getBuildVariables());
 
         if (buildSucceed) {
             try {
-                final MarathonBuilder builder = MarathonBuilder.getBuilder(this)
+                MarathonBuilder builder = MarathonBuilder.getBuilder(this)
                         .setEnvVars(envVars).setWorkspace(build.getWorkspace())
                         .read(this.filename)
                         .build().toFile();
@@ -182,66 +184,83 @@ public class MarathonRecorder extends Recorder implements AppConfig {
         return this.appid;
     }
 
+    @Override
     public String getUrl() {
-        return url;
+        return this.url;
     }
 
     @Override
     public boolean getForceUpdate() {
-        return forceUpdate;
+        return this.forceUpdate;
     }
 
+    @Override
     public String getDocker() {
-        return docker;
+        return this.docker;
     }
 
+    @DataBoundSetter
+    public void setDocker(@Nonnull String docker) {
+        this.docker = docker;
+    }
+
+    @Override
     public boolean getDockerForcePull() {
-        return dockerForcePull;
+        return this.dockerForcePull;
     }
 
+    @DataBoundSetter
+    public void setDockerForcePull(@Nonnull boolean dockerForcePull) {
+        this.dockerForcePull = dockerForcePull;
+    }
+
+    @Override
     public String getCredentialsId() {
         return this.credentialsId;
     }
 
     @DataBoundSetter
-    public void setCredentialsId(final String credentialsId) {
+    public void setCredentialsId(String credentialsId) {
         this.credentialsId = credentialsId;
     }
 
+    @Override
     public List<MarathonUri> getUris() {
-        return uris;
+        return this.uris;
     }
 
     @DataBoundSetter
-    public void setUris(final List<MarathonUri> uris) {
+    public void setUris(List<MarathonUri> uris) {
         this.uris = uris;
     }
 
+    @Override
     public List<MarathonLabel> getLabels() {
-        return labels;
+        return this.labels;
     }
 
     @DataBoundSetter
-    public void setLabels(final List<MarathonLabel> labels) {
+    public void setLabels(List<MarathonLabel> labels) {
         this.labels = labels;
     }
 
-    @DataBoundSetter
-    public void setDocker(@Nonnull final String docker) {
-        this.docker = docker;
-    }
-
-    @DataBoundSetter
-    public void setDockerForcePull(@Nonnull final boolean dockerForcePull) {
-        this.dockerForcePull = dockerForcePull;
-    }
-
+    @Override
     public List<MarathonVars> getEnv() {
-        return env;
+        return this.env;
+    }
+
+    @Override
+    public long getTimeout() {
+        return this.timeout;
     }
 
     @DataBoundSetter
-    public void setEnvironment(final List<MarathonVars> env) {
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+
+    @DataBoundSetter
+    public void setEnvironment(List<MarathonVars> env) {
         this.env = env;
     }
 
@@ -255,7 +274,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setForceUpdate(final boolean forceUpdate) {
+    public void setForceUpdate(boolean forceUpdate) {
         this.forceUpdate = forceUpdate;
     }
 
@@ -264,7 +283,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
             load();
         }
 
-        private boolean isUrl(final String url) {
+        private boolean isUrl(String url) {
             boolean valid = false;
 
             if (url != null && url.length() > 0) {
@@ -289,18 +308,28 @@ public class MarathonRecorder extends Recorder implements AppConfig {
             );
         }
 
-        private FormValidation verifyUrl(final String url) {
-            if (!isUrl(url))
+        private FormValidation verifyUrl(String url) {
+            if (!isUrl(url)) {
                 return FormValidation.error("Not a valid URL");
+            }
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckUrl(@QueryParameter final String value) {
+        public FormValidation doCheckUrl(@QueryParameter String value) {
             return verifyUrl(value);
         }
 
-        public FormValidation doCheckUri(@QueryParameter final String value) {
+        public FormValidation doCheckUri(@QueryParameter String value) {
             return verifyUrl(value);
+        }
+
+        public FormValidation doCheckTimeout(@QueryParameter String value) {
+            try {
+                Long.getLong(value);
+                return FormValidation.ok();
+            } catch (NumberFormatException e) {
+                return FormValidation.error("Invalid number format.");
+            }
         }
 
         @Override

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
@@ -56,32 +56,32 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     private       String              filename;
     private       String              credentialsId;
     private       boolean             forceUpdate;
-    private long timeout;
+    private       long                timeout;
 
     @DataBoundConstructor
-    public MarathonRecorder(String url) {
+    public MarathonRecorder(final String url) {
         this.url = MarathonBuilderUtils.rmSlashFromUrl(url);
 
-        this.uris = new ArrayList<>(5);
-        this.labels = new ArrayList<>(5);
-        this.env = new ArrayList<>(5);
+        this.uris = new ArrayList<MarathonUri>(5);
+        this.labels = new ArrayList<MarathonLabel>(5);
+        this.env = new ArrayList<MarathonVars>(5);
     }
 
     public String getAppid() {
-        return this.appid;
+        return appid;
     }
 
     @DataBoundSetter
-    public void setAppid(@Nonnull String appid) {
+    public void setAppid(@Nonnull final String appid) {
         this.appid = appid;
     }
 
     public String getFilename() {
-        return this.filename;
+        return filename;
     }
 
     @DataBoundSetter
-    public void setFilename(@Nonnull String filename) {
+    public void setFilename(@Nonnull final String filename) {
         if (filename.trim().length() > 0) {
             this.filename = filename;
         }
@@ -110,21 +110,21 @@ public class MarathonRecorder extends Recorder implements AppConfig {
      * @param logger a build's logger
      * @param text   message to log
      */
-    private void log(PrintStream logger, String text) {
+    private void log(final PrintStream logger, final String text) {
         logger.println("[Marathon] " + text);
     }
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-        boolean buildSucceed = build.getResult() == null || build.getResult() == Result.SUCCESS;
-        EnvVars envVars = build.getEnvironment(listener);
-        PrintStream logger = listener.getLogger();
+        final boolean buildSucceed = build.getResult() == null || build.getResult() == Result.SUCCESS;
+        final EnvVars envVars = build.getEnvironment(listener);
+        final PrintStream logger = listener.getLogger();
         envVars.overrideAll(build.getBuildVariables());
 
         if (buildSucceed) {
             try {
-                MarathonBuilder builder = MarathonBuilder.getBuilder(this)
+                final MarathonBuilder builder = MarathonBuilder.getBuilder(this)
                         .setEnvVars(envVars).setWorkspace(build.getWorkspace())
                         .read(this.filename)
                         .build().toFile();
@@ -181,22 +181,22 @@ public class MarathonRecorder extends Recorder implements AppConfig {
 
     @Override
     public String getAppId() {
-        return this.appid;
+        return appid;
     }
 
     @Override
     public String getUrl() {
-        return this.url;
+        return url;
     }
 
     @Override
     public boolean getForceUpdate() {
-        return this.forceUpdate;
+        return forceUpdate;
     }
 
     @Override
     public String getDocker() {
-        return this.docker;
+        return docker;
     }
 
     @DataBoundSetter
@@ -206,7 +206,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
 
     @Override
     public boolean getDockerForcePull() {
-        return this.dockerForcePull;
+        return dockerForcePull;
     }
 
     @DataBoundSetter
@@ -216,42 +216,42 @@ public class MarathonRecorder extends Recorder implements AppConfig {
 
     @Override
     public String getCredentialsId() {
-        return this.credentialsId;
+        return credentialsId;
     }
 
     @DataBoundSetter
-    public void setCredentialsId(String credentialsId) {
+    public void setCredentialsId(final String credentialsId) {
         this.credentialsId = credentialsId;
     }
 
     @Override
     public List<MarathonUri> getUris() {
-        return this.uris;
+        return uris;
     }
 
     @DataBoundSetter
-    public void setUris(List<MarathonUri> uris) {
+    public void setUris(final List<MarathonUri> uris) {
         this.uris = uris;
     }
 
     @Override
     public List<MarathonLabel> getLabels() {
-        return this.labels;
+        return labels;
     }
 
     @DataBoundSetter
-    public void setLabels(List<MarathonLabel> labels) {
+    public void setLabels(final List<MarathonLabel> labels) {
         this.labels = labels;
     }
 
     @Override
     public List<MarathonVars> getEnv() {
-        return this.env;
+        return env;
     }
 
     @Override
     public long getTimeout() {
-        return this.timeout;
+        return timeout;
     }
 
     @DataBoundSetter
@@ -260,7 +260,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setEnvironment(List<MarathonVars> env) {
+    public void setEnvironment(final List<MarathonVars> env) {
         this.env = env;
     }
 
@@ -274,7 +274,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setForceUpdate(boolean forceUpdate) {
+    public void setForceUpdate(final boolean forceUpdate) {
         this.forceUpdate = forceUpdate;
     }
 
@@ -283,7 +283,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
             load();
         }
 
-        private boolean isUrl(String url) {
+        private boolean isUrl(final String url) {
             boolean valid = false;
 
             if (url != null && url.length() > 0) {
@@ -308,18 +308,18 @@ public class MarathonRecorder extends Recorder implements AppConfig {
             );
         }
 
-        private FormValidation verifyUrl(String url) {
+        private FormValidation verifyUrl(final String url) {
             if (!isUrl(url)) {
                 return FormValidation.error("Not a valid URL");
             }
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckUrl(@QueryParameter String value) {
+        public FormValidation doCheckUrl(@QueryParameter final String value) {
             return verifyUrl(value);
         }
 
-        public FormValidation doCheckUri(@QueryParameter String value) {
+        public FormValidation doCheckUri(@QueryParameter final String value) {
             return verifyUrl(value);
         }
 

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
@@ -44,14 +44,14 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     private       String              filename;
     private       String              credentialsId;
     private       boolean             forceUpdate;
-    private long timeout;
+    private       long                timeout;
 
     @DataBoundConstructor
     public MarathonStep(String url) {
         this.url = MarathonBuilderUtils.rmSlashFromUrl(url);
-        this.uris = new ArrayList<>(5);
-        this.labels = new ArrayList<>(5);
-        this.env = new ArrayList<>(5);
+        this.uris = new ArrayList<MarathonUri>(5);
+        this.labels = new ArrayList<MarathonLabel>(5);
+        this.env = new ArrayList<MarathonVars>(5);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
 
     @Override
     public String getUrl() {
-        return this.url;
+        return url;
     }
 
     @Override
@@ -70,21 +70,21 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setForceUpdate(boolean forceUpdate) {
+    public void setForceUpdate(final boolean forceUpdate) {
         this.forceUpdate = forceUpdate;
     }
 
     @Override
     public List<MarathonVars> getEnv() {
-        List<MarathonVars> marathonVarsList = new ArrayList<>(this.env.size());
-        for (MarathonVars envElem : this.env) {
+        final List<MarathonVars> marathonVarsList = new ArrayList<>(this.env.size());
+        for (final MarathonVars envElem : this.env) {
             marathonVarsList.add(new MarathonVars(envElem.getName(), envElem.getValue()));
         }
         return marathonVarsList;
     }
 
     @DataBoundSetter
-    public void setEnv(List<MarathonVars> env) {
+    public void setEnv(final List<MarathonVars> env) {
         this.env = env;
     }
 
@@ -94,7 +94,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setDocker(String docker) {
+    public void setDocker(final String docker) {
         this.docker = docker;
     }
 
@@ -104,7 +104,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setDockerForcePull(boolean dockerForcePull) {
+    public void setDockerForcePull(final boolean dockerForcePull) {
         this.dockerForcePull = dockerForcePull;
     }
 
@@ -114,35 +114,35 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setCredentialsId(String credentialsId) {
+    public void setCredentialsId(final String credentialsId) {
         this.credentialsId = credentialsId;
     }
 
     @Override
     public List<MarathonUri> getUris() {
-        List<MarathonUri> marathonUris = new ArrayList<>(this.uris.size());
-        for (MarathonUri u : this.uris) {
+        final List<MarathonUri> marathonUris = new ArrayList<>(this.uris.size());
+        for (final MarathonUri u : this.uris) {
             marathonUris.add(new MarathonUri(u.getUri()));
         }
         return marathonUris;
     }
 
     @DataBoundSetter
-    public void setUris(List<MarathonUri> uris) {
+    public void setUris(final List<MarathonUri> uris) {
         this.uris = uris;
     }
 
     @Override
     public List<MarathonLabel> getLabels() {
-        List<MarathonLabel> marathonLabels = new ArrayList<>(this.labels.size());
-        for (MarathonLabel label : this.labels) {
+        final List<MarathonLabel> marathonLabels = new ArrayList<>(this.labels.size());
+        for (final MarathonLabel label : this.labels) {
             marathonLabels.add(new MarathonLabel(label.getName(), label.getValue()));
         }
         return marathonLabels;
     }
 
     @DataBoundSetter
-    public void setLabels(List<MarathonLabel> labels) {
+    public void setLabels(final List<MarathonLabel> labels) {
         this.labels = labels;
     }
 
@@ -165,7 +165,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
      */
     @Deprecated
     @DataBoundSetter
-    public void setAppid(String appid) {
+    public void setAppid(final String appid) {
         this.appid = appid;
     }
 
@@ -174,10 +174,9 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setFilename(@Nonnull String filename) {
-        if (filename.trim().length() > 0) {
+    public void setFilename(@Nonnull final String filename) {
+        if (filename.trim().length() > 0)
             this.filename = filename;
-        }
     }
 
     @Override
@@ -186,7 +185,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     }
 
     @DataBoundSetter
-    public void setTimeout(long timeout) {
+    public void setTimeout(final long timeout) {
         this.timeout = timeout;
     }
 
@@ -207,7 +206,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
      * @since 1.3.3
      */
     @DataBoundSetter
-    public void setId(String id) {
+    public void setId(final String id) {
         this.id = id;
     }
 
@@ -220,11 +219,11 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
             super(MarathonStepExecution.class);
         }
 
-        public FormValidation doCheckUrl(@QueryParameter String value) {
+        public FormValidation doCheckUrl(@QueryParameter final String value) {
             return this.delegate.doCheckUrl(value);
         }
 
-        public FormValidation doCheckUri(@QueryParameter String value) {
+        public FormValidation doCheckUri(@QueryParameter final String value) {
             return this.delegate.doCheckUri(value);
         }
 
@@ -277,7 +276,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
                         .toFile()
                         .update();
             } catch (MarathonException | MarathonFileInvalidException | MarathonFileMissingException me) {
-                String errorMsg = String.format("[Marathon] %s", me.getMessage());
+                final String errorMsg = String.format("[Marathon] %s", me.getMessage());
                 this.listener.error(errorMsg);
                 this.run.setResult(Result.FAILURE);
             }

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
@@ -1,0 +1,78 @@
+package com.mesosphere.velocity.marathon.impl;
+
+import com.mesosphere.velocity.marathon.interfaces.MarathonApi;
+import mesosphere.marathon.client.Marathon;
+import mesosphere.marathon.client.model.v2.App;
+import mesosphere.marathon.client.model.v2.Result;
+
+import java.util.logging.Logger;
+
+public class MarathonApiImpl implements MarathonApi {
+    private static final Logger LOGGER = Logger.getLogger(MarathonApiImpl.class.getName());
+
+    public MarathonApiImpl() {
+    }
+
+    /**
+     * wait for n seconds
+     *
+     * @param seconds
+     */
+    private static void waitForSeconds(int seconds) {
+        if (seconds > 0) {
+            try {
+                Thread.sleep(seconds * 1000L);
+            } catch (InterruptedException e) {
+                LOGGER.warning("A problem occured while waiting on a thread. The reason is: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Updating an app. If the timeout set by a value > 0, the method will wait until the deployment is done.
+     *
+     * @param client
+     * @param app
+     * @param forceUpdate
+     * @param timeout
+     * @return information, if the app could be deployed within a timaout range.
+     */
+    @Override
+    public boolean update(Marathon client, App app, boolean forceUpdate, long timeout) {
+        if (client == null || app == null) {
+            throw new IllegalArgumentException("Necessary parameters are not set!");
+        }
+
+        Result result = client.updateApp(app.getId(), app, forceUpdate);
+        boolean success = false;
+        if (timeout > 0) {
+            if (result != null && result.getDeploymentId() != null) {
+                LOGGER.info(String.format("Create deployment with id: '%s'", result.getDeploymentId()));
+                success = waitForDeploymentHasFinished(client, result.getDeploymentId(), timeout);
+            } else {
+                LOGGER.warning(String.format("Could not create deployment for app: '%s'", app != null ? app : "null"));
+            }
+        } else {
+            success = true;
+        }
+        return success;
+    }
+
+    private boolean waitForDeploymentHasFinished(Marathon client, String deploymentId, long timeout) {
+        LOGGER.info(String.format("Waiting for deployment with id='%s' has finished.", deploymentId != null ? deploymentId : "null"));
+        boolean isActive = true;
+        long startTimestamp = System.currentTimeMillis();
+        while (isActive) {
+            waitForSeconds(5); // 5 seconds
+            isActive = client.getDeployments().parallelStream() //
+                    .filter(deployment -> deployment.getId().equals(deploymentId)) //
+                    .findFirst() //
+                    .isPresent();
+            if (timeout > 0 && (System.currentTimeMillis() - startTimestamp) >= timeout) {
+                LOGGER.warning(String.format("The deployment with id='%s' has timed out after %dms.", deploymentId != null ? deploymentId : "null", timeout));
+                break;
+            }
+        }
+        return !isActive;
+    }
+}

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
@@ -5,27 +5,14 @@ import mesosphere.marathon.client.Marathon;
 import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.Result;
 
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 public class MarathonApiImpl implements MarathonApi {
     private static final Logger LOGGER = Logger.getLogger(MarathonApiImpl.class.getName());
+    private static final int CHECK_DEPLOYMENT_WAIT_FREQUENCY_SECS = 5;
 
     public MarathonApiImpl() {
-    }
-
-    /**
-     * wait for n seconds
-     *
-     * @param seconds
-     */
-    private static void waitForSeconds(int seconds) {
-        if (seconds > 0) {
-            try {
-                Thread.sleep(seconds * 1000L);
-            } catch (InterruptedException e) {
-                LOGGER.warning("A problem occured while waiting on a thread. The reason is: " + e.getMessage());
-            }
-        }
     }
 
     /**
@@ -35,44 +22,46 @@ public class MarathonApiImpl implements MarathonApi {
      * @param app
      * @param forceUpdate
      * @param timeout
-     * @return information, if the app could be deployed within a timaout range.
+     * @throws TimeoutException the deployment timed out after the given timeout value
      */
     @Override
-    public boolean update(Marathon client, App app, boolean forceUpdate, long timeout) {
+    public void update(Marathon client, App app, boolean forceUpdate, long timeout) throws TimeoutException {
         if (client == null || app == null) {
             throw new IllegalArgumentException("Necessary parameters are not set!");
         }
 
         Result result = client.updateApp(app.getId(), app, forceUpdate);
-        boolean success = false;
         if (timeout > 0) {
             if (result != null && result.getDeploymentId() != null) {
                 LOGGER.info(String.format("Create deployment with id: '%s'", result.getDeploymentId()));
-                success = waitForDeploymentHasFinished(client, result.getDeploymentId(), timeout);
+                waitForDeploymentHasFinished(client, result.getDeploymentId(), timeout);
             } else {
                 LOGGER.warning(String.format("Could not create deployment for app: '%s'", app != null ? app : "null"));
             }
-        } else {
-            success = true;
         }
-        return success;
     }
 
-    private boolean waitForDeploymentHasFinished(Marathon client, String deploymentId, long timeout) {
+    private static void waitForDeploymentHasFinished(Marathon client, String deploymentId, long timeout) throws TimeoutException {
         LOGGER.info(String.format("Waiting for deployment with id='%s' has finished.", deploymentId != null ? deploymentId : "null"));
-        boolean isActive = true;
-        long startTimestamp = System.currentTimeMillis();
-        while (isActive) {
-            waitForSeconds(5); // 5 seconds
-            isActive = client.getDeployments().parallelStream() //
+        final long startTimestamp = System.currentTimeMillis();
+        while (true) {
+            final boolean isDeploymentActive = client.getDeployments().parallelStream() //
                     .filter(deployment -> deployment.getId().equals(deploymentId)) //
                     .findFirst() //
                     .isPresent();
-            if (timeout > 0 && (System.currentTimeMillis() - startTimestamp) >= timeout) {
-                LOGGER.warning(String.format("The deployment with id='%s' has timed out after %dms.", deploymentId != null ? deploymentId : "null", timeout));
+            if(!isDeploymentActive){
+                break;
+            }else if(timeout > 0 && (System.currentTimeMillis() - startTimestamp) >= timeout) {
+                final String timeoutMessage = String.format("The deployment with id='%s' has timed out after %dms.", deploymentId != null ? deploymentId : "null", timeout);
+                LOGGER.warning(timeoutMessage);
+                throw new TimeoutException(timeoutMessage);
+            }
+            try {
+                Thread.sleep(CHECK_DEPLOYMENT_WAIT_FREQUENCY_SECS * 1000L);
+            } catch (InterruptedException e) {
+                LOGGER.warning("A problem occured while waiting on a thread. The reason is: " + e.getMessage());
                 break;
             }
         }
-        return !isActive;
     }
 }

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonApiImpl.java
@@ -16,12 +16,12 @@ public class MarathonApiImpl implements MarathonApi {
     }
 
     /**
-     * Updating an app. If the timeout set by a value > 0, the method will wait until the deployment is done.
+     * Updating an app. If the timeout set by a value greater then 0, the method will wait until the deployment is done.
      *
-     * @param client
-     * @param app
-     * @param forceUpdate
-     * @param timeout
+     * @param client Marathon client
+     * @param app Marathon app model
+     * @param forceUpdate force updating a deployment of a service
+     * @param timeout number of milliseconds after the deployment should time out
      * @throws TimeoutException the deployment timed out after the given timeout value
      */
     @Override

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
@@ -221,10 +221,9 @@ public class MarathonBuilderImpl extends MarathonBuilder {
         }
 
         if (client != null) {
-            long timeout = 5 * 60 * 1000L; // timeout after 5 min
-            boolean success = new MarathonApiImpl().update(client, getApp(), this.config.getForceUpdate(), timeout);
+            boolean success = new MarathonApiImpl().update(client, getApp(), this.config.getForceUpdate(), this.config.getTimeout());
             if (!success) {
-                throw new MarathonException(408, String.format("The deployment timed out after %dms", timeout));
+                throw new MarathonException(408, String.format("The deployment timed out after %dms", this.config.getTimeout()));
             }
         }
     }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
@@ -73,4 +73,11 @@ public interface AppConfig {
      * @return list of environment variables
      */
     List<MarathonVars> getEnv();
+
+    /**
+     * Return the value after a deployment times out
+     *
+     * @return
+     */
+    long getTimeout();
 }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
@@ -77,7 +77,7 @@ public interface AppConfig {
     /**
      * Return the value after a deployment times out
      *
-     * @return
+     * @return timeout value in milliseconds
      */
     long getTimeout();
 }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/MarathonApi.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/MarathonApi.java
@@ -3,6 +3,8 @@ package com.mesosphere.velocity.marathon.interfaces;
 import mesosphere.marathon.client.Marathon;
 import mesosphere.marathon.client.model.v2.App;
 
+import java.util.concurrent.TimeoutException;
+
 public interface MarathonApi {
 
     /**
@@ -12,7 +14,7 @@ public interface MarathonApi {
      * @param app
      * @param forceUpdate
      * @param timeout
-     * @return the result, whether a deployment
+     * @throws TimeoutException the deployment timed out after the given timeout value
      */
-    boolean update(Marathon client, App app, boolean forceUpdate, long timeout);
+    void update(Marathon client, App app, boolean forceUpdate, long timeout) throws TimeoutException;
 }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/MarathonApi.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/MarathonApi.java
@@ -1,0 +1,18 @@
+package com.mesosphere.velocity.marathon.interfaces;
+
+import mesosphere.marathon.client.Marathon;
+import mesosphere.marathon.client.model.v2.App;
+
+public interface MarathonApi {
+
+    /**
+     * API for deploying
+     *
+     * @param client
+     * @param app
+     * @param forceUpdate
+     * @param timeout
+     * @return the result, whether a deployment
+     */
+    boolean update(Marathon client, App app, boolean forceUpdate, long timeout);
+}

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
@@ -13,6 +13,10 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%Timeout}" field="timeout">
+        <f:textbox/>
+    </f:entry>
+
         <f:advanced>
             <f:entry title="${%Definition File}" field="filename">
                 <f:textbox />

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-timeout.html
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-timeout.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This parameter defines the time, when an active deployment can not be completed and times out.
+    </p>
+</div>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
@@ -17,6 +17,10 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%Timeout}" field="timeout">
+        <f:textbox/>
+    </f:entry>
+
         <f:advanced>
             <f:entry title="${%Definition File}" field="filename">
                 <f:textbox/>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/help-timeout.html
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/help-timeout.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This parameter defines the time, when an active deployment can not be completed and times out.
+    </p>
+</div>

--- a/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonApiImplTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonApiImplTest.java
@@ -1,0 +1,86 @@
+package com.mesosphere.velocity.marathon.impl;
+
+import com.mesosphere.velocity.marathon.interfaces.MarathonApi;
+import mesosphere.marathon.client.Marathon;
+import mesosphere.marathon.client.model.v2.App;
+import mesosphere.marathon.client.model.v2.Deployment;
+import mesosphere.marathon.client.model.v2.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MarathonApiImplTest {
+
+    private static final boolean DEFAULT_TEST_FORCEUPDATE = true;
+    private static final long DEFAULT_TEST_TIMEOUT = 2000L;
+    private static final String TEST_APP_ID = "/test/appId";
+    private static final String TEST_DEPLOYMENT_ID = "1234-5678";
+
+    private MarathonApi marathonApi;
+    private Marathon client;
+    private App app;
+
+    @Before
+    public void setUp() throws Exception {
+        this.marathonApi = new MarathonApiImpl();
+        this.app = mock(App.class);
+        when(this.app.getId()).thenReturn(TEST_APP_ID);
+        this.client = mock(Marathon.class);
+    }
+
+    @Test
+    public void testUpdate_deploymentSuccessfull() throws Exception {
+        // given
+        boolean forceUpdate = DEFAULT_TEST_FORCEUPDATE;
+        long timeout = DEFAULT_TEST_TIMEOUT;
+        Result result = mock(Result.class);
+        when(result.getDeploymentId()).thenReturn(TEST_DEPLOYMENT_ID);
+        when(this.client.updateApp(this.app.getId(), this.app, forceUpdate)).thenReturn(result);
+        // when
+        boolean success = this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
+        // then
+        assertTrue(success);
+    }
+
+    @Test
+    public void testUpdate_deploymentTimedout() throws Exception {
+        // given
+        boolean forceUpdate = DEFAULT_TEST_FORCEUPDATE;
+        long timeout = DEFAULT_TEST_TIMEOUT;
+        Result result = mock(Result.class);
+        when(result.getDeploymentId()).thenReturn(TEST_DEPLOYMENT_ID);
+        when(this.client.updateApp(this.app.getId(), this.app, forceUpdate)).thenReturn(result);
+
+        Deployment deployment = mock(Deployment.class);
+        when(deployment.getId()).thenReturn(TEST_DEPLOYMENT_ID);
+        when(this.client.getDeployments()).thenReturn(Arrays.asList(deployment));
+        // when
+        boolean success = this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
+        // then
+        assertFalse(success);
+    }
+
+    @Test(expected = IllegalArgumentException.class) // then
+    public void testUpdate_clientNotSet() throws Exception {
+        // given
+        boolean forceUpdate = DEFAULT_TEST_FORCEUPDATE;
+        long timeout = DEFAULT_TEST_TIMEOUT;
+        // when
+        this.marathonApi.update(null, this.app, forceUpdate, timeout);
+    }
+
+    @Test(expected = IllegalArgumentException.class) // then
+    public void testUpdate_appNotSet() throws Exception {
+        // given
+        boolean forceUpdate = DEFAULT_TEST_FORCEUPDATE;
+        long timeout = DEFAULT_TEST_TIMEOUT;
+        // when
+        this.marathonApi.update(this.client, null, forceUpdate, timeout);
+    }
+}

--- a/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonApiImplTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonApiImplTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -43,12 +44,11 @@ public class MarathonApiImplTest {
         when(result.getDeploymentId()).thenReturn(TEST_DEPLOYMENT_ID);
         when(this.client.updateApp(this.app.getId(), this.app, forceUpdate)).thenReturn(result);
         // when
-        boolean success = this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
+        this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
         // then
-        assertTrue(success);
     }
 
-    @Test
+    @Test(expected = TimeoutException.class) //then
     public void testUpdate_deploymentTimedout() throws Exception {
         // given
         boolean forceUpdate = DEFAULT_TEST_FORCEUPDATE;
@@ -61,9 +61,7 @@ public class MarathonApiImplTest {
         when(deployment.getId()).thenReturn(TEST_DEPLOYMENT_ID);
         when(this.client.getDeployments()).thenReturn(Arrays.asList(deployment));
         // when
-        boolean success = this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
-        // then
-        assertFalse(success);
+        this.marathonApi.update(this.client, this.app, forceUpdate, timeout);
     }
 
     @Test(expected = IllegalArgumentException.class) // then

--- a/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
@@ -25,14 +25,14 @@ public class MarathonBuilderImplTest {
 
     @Before
     public void setUp() throws IOException {
-        httpServer = new MockWebServer();
-        httpServer.start();
+        this.httpServer = new MockWebServer();
+        this.httpServer.start();
     }
 
     @After
     public void tearDown() throws IOException {
-        httpServer.shutdown();
-        httpServer = null;
+        this.httpServer.shutdown();
+        this.httpServer = null;
     }
 
     /**
@@ -47,25 +47,25 @@ public class MarathonBuilderImplTest {
         MockConfig config  = new MockConfig();
         String     payload = TestUtils.loadFixture("allfields.json");
         JSONObject json    = JSONObject.fromObject(payload);
-        config.url = TestUtils.getHttpAddresss(httpServer);
+        config.url = TestUtils.getHttpAddresss(this.httpServer);
 
-        TestUtils.enqueueJsonResponse(httpServer, "{}");
+        TestUtils.enqueueJsonResponse(this.httpServer, "{}");
         new MarathonBuilderImpl(config)
                 .setJson(json)
                 .build()
                 .update();
-        final JSONObject jsonRequest = TestUtils.jsonFromRequest(httpServer);
+        JSONObject jsonRequest = TestUtils.jsonFromRequest(this.httpServer);
         assertEquals("JSON objects are different", json, jsonRequest);
 
         // secrets
-        final JSONObject secrets = jsonRequest.getJSONObject("secrets");
-        final JSONObject secret3 = secrets.getJSONObject("secret3");
+        JSONObject secrets = jsonRequest.getJSONObject("secrets");
+        JSONObject secret3 = secrets.getJSONObject("secret3");
         assertEquals("Wrong source for secret3", "/foo2", secret3.getString("source"));
 
         // secrets in env
-        final JSONObject env            = jsonRequest.getJSONObject("env");
-        final String     actualPassword = env.getJSONObject("PASSWORD").getString("secret");
-        final String     actualXPS2     = env.getString("XPS2");
+        JSONObject env = jsonRequest.getJSONObject("env");
+        String actualPassword = env.getJSONObject("PASSWORD").getString("secret");
+        String actualXPS2 = env.getString("XPS2");
         assertEquals("Invalid value for PASSWORD", "/db/password", actualPassword);
         assertEquals("Invalid value for XPS2", "Rest", actualXPS2);
     }
@@ -75,9 +75,9 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testNoUris() throws IOException {
-        final String     jsonString = TestUtils.loadFixture("idonly.json");
-        final JSONObject json       = JSONObject.fromObject(jsonString);
-        final MockConfig config     = new MockConfig();
+        String jsonString = TestUtils.loadFixture("idonly.json");
+        JSONObject json = JSONObject.fromObject(jsonString);
+        MockConfig config = new MockConfig();
 
         MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
         assertNull("URIs should be null if none were in the JSON config", builder.getApp().getUris());
@@ -88,8 +88,8 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testExistingUris() throws IOException {
-        final String     jsonString = TestUtils.loadFixture("uris.json");
-        final JSONObject json       = JSONObject.fromObject(jsonString);
+        String jsonString = TestUtils.loadFixture("uris.json");
+        JSONObject json = JSONObject.fromObject(jsonString);
 
         MarathonBuilder builder = new MarathonBuilderImpl(new MockConfig()).setJson(json).build();
         assertEquals(2, builder.getJson().getJSONArray("uris").size());
@@ -103,9 +103,9 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testInvalidTypeUris() {
-        final String     jsonString = "{\"id\": \"testid\", \"uris\": \"http://example.com/artifact\"}";
-        final JSONObject json       = JSONObject.fromObject(jsonString);
-        final MockConfig config     = new MockConfig();
+        String jsonString = "{\"id\": \"testid\", \"uris\": \"http://example.com/artifact\"}";
+        JSONObject json = JSONObject.fromObject(jsonString);
+        MockConfig config = new MockConfig();
 
         try {
             new MarathonBuilderImpl(config).setJson(json).build();
@@ -120,9 +120,9 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testExistingEnv() throws IOException {
-        final String     jsonString = TestUtils.loadFixture("env.json");
-        final JSONObject json       = JSONObject.fromObject(jsonString);
-        final MockConfig config     = new MockConfig();
+        String jsonString = TestUtils.loadFixture("env.json");
+        JSONObject json = JSONObject.fromObject(jsonString);
+        MockConfig config = new MockConfig();
 
         // add to the env
         config.env.add(new MarathonVars("example", "test"));
@@ -139,9 +139,9 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testNoEnv() throws IOException {
-        final String     jsonString = TestUtils.loadFixture("idonly.json");
-        final JSONObject json       = JSONObject.fromObject(jsonString);
-        final MockConfig config     = new MockConfig();
+        String jsonString = TestUtils.loadFixture("idonly.json");
+        JSONObject json = JSONObject.fromObject(jsonString);
+        MockConfig config = new MockConfig();
         MarathonBuilder  builder    = new MarathonBuilderImpl(config).setJson(json).build();
         assertNull("Env should be null", builder.getApp().getEnv());
 
@@ -161,56 +161,62 @@ public class MarathonBuilderImplTest {
         List<MarathonUri>   uris;
         List<MarathonLabel> labels;
         List<MarathonVars>  env;
+        long timeout;
 
         MockConfig() {
-            uris = new ArrayList<>();
-            labels = new ArrayList<>();
-            env = new ArrayList<>();
+            this.uris = new ArrayList<>();
+            this.labels = new ArrayList<>();
+            this.env = new ArrayList<>();
         }
 
         @Override
         public String getAppId() {
-            return appId;
+            return this.appId;
         }
 
         @Override
         public String getUrl() {
-            return url;
+            return this.url;
         }
 
         @Override
         public boolean getForceUpdate() {
-            return forceUpdate;
+            return this.forceUpdate;
         }
 
         @Override
         public String getDocker() {
-            return docker;
+            return this.docker;
         }
 
         @Override
         public boolean getDockerForcePull() {
-            return dockerForcePull;
+            return this.dockerForcePull;
         }
 
         @Override
         public String getCredentialsId() {
-            return credentialsId;
+            return this.credentialsId;
         }
 
         @Override
         public List<MarathonUri> getUris() {
-            return uris;
+            return this.uris;
         }
 
         @Override
         public List<MarathonLabel> getLabels() {
-            return labels;
+            return this.labels;
         }
 
         @Override
         public List<MarathonVars> getEnv() {
-            return env;
+            return this.env;
+        }
+
+        @Override
+        public long getTimeout() {
+            return this.timeout;
         }
     }
 }

--- a/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
@@ -47,25 +47,25 @@ public class MarathonBuilderImplTest {
         MockConfig config  = new MockConfig();
         String     payload = TestUtils.loadFixture("allfields.json");
         JSONObject json    = JSONObject.fromObject(payload);
-        config.url = TestUtils.getHttpAddresss(this.httpServer);
+        config.url = TestUtils.getHttpAddresss(httpServer);
 
-        TestUtils.enqueueJsonResponse(this.httpServer, "{}");
+        TestUtils.enqueueJsonResponse(httpServer, "{}");
         new MarathonBuilderImpl(config)
                 .setJson(json)
                 .build()
                 .update();
-        JSONObject jsonRequest = TestUtils.jsonFromRequest(this.httpServer);
+        final JSONObject jsonRequest = TestUtils.jsonFromRequest(httpServer);
         assertEquals("JSON objects are different", json, jsonRequest);
 
         // secrets
-        JSONObject secrets = jsonRequest.getJSONObject("secrets");
-        JSONObject secret3 = secrets.getJSONObject("secret3");
+        final JSONObject secrets = jsonRequest.getJSONObject("secrets");
+        final JSONObject secret3 = secrets.getJSONObject("secret3");
         assertEquals("Wrong source for secret3", "/foo2", secret3.getString("source"));
 
         // secrets in env
-        JSONObject env = jsonRequest.getJSONObject("env");
-        String actualPassword = env.getJSONObject("PASSWORD").getString("secret");
-        String actualXPS2 = env.getString("XPS2");
+        final JSONObject env = jsonRequest.getJSONObject("env");
+        final String actualPassword = env.getJSONObject("PASSWORD").getString("secret");
+        final String actualXPS2 = env.getString("XPS2");
         assertEquals("Invalid value for PASSWORD", "/db/password", actualPassword);
         assertEquals("Invalid value for XPS2", "Rest", actualXPS2);
     }
@@ -75,11 +75,11 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testNoUris() throws IOException {
-        String jsonString = TestUtils.loadFixture("idonly.json");
-        JSONObject json = JSONObject.fromObject(jsonString);
-        MockConfig config = new MockConfig();
+        final String jsonString = TestUtils.loadFixture("idonly.json");
+        final JSONObject json = JSONObject.fromObject(jsonString);
+        final MockConfig config = new MockConfig();
 
-        MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
+        final MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
         assertNull("URIs should be null if none were in the JSON config", builder.getApp().getUris());
     }
 
@@ -88,10 +88,10 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testExistingUris() throws IOException {
-        String jsonString = TestUtils.loadFixture("uris.json");
-        JSONObject json = JSONObject.fromObject(jsonString);
+        final String jsonString = TestUtils.loadFixture("uris.json");
+        final JSONObject json = JSONObject.fromObject(jsonString);
 
-        MarathonBuilder builder = new MarathonBuilderImpl(new MockConfig()).setJson(json).build();
+        final MarathonBuilder builder = new MarathonBuilderImpl(new MockConfig()).setJson(json).build();
         assertEquals(2, builder.getJson().getJSONArray("uris").size());
         assertEquals(2, builder.getApp().getUris().size());
         assertEquals("https://foo.com/setup.py", builder.getApp().getUris().iterator().next());
@@ -101,18 +101,13 @@ public class MarathonBuilderImplTest {
      * Test that an invalid "uris" format causes a JSON exception. The "uris" field should
      * be an array.
      */
-    @Test
+    @Test(expected = JsonSyntaxException.class)
     public void testInvalidTypeUris() {
-        String jsonString = "{\"id\": \"testid\", \"uris\": \"http://example.com/artifact\"}";
-        JSONObject json = JSONObject.fromObject(jsonString);
-        MockConfig config = new MockConfig();
+        final String jsonString = "{\"id\": \"testid\", \"uris\": \"http://example.com/artifact\"}";
+        final JSONObject json = JSONObject.fromObject(jsonString);
+        final MockConfig config = new MockConfig();
 
-        try {
-            new MarathonBuilderImpl(config).setJson(json).build();
-            assertTrue("Should throw json parse exception", false);
-        } catch (JsonSyntaxException jse) {
-            assertTrue(true);
-        }
+        new MarathonBuilderImpl(config).setJson(json).build();
     }
 
     /**
@@ -120,14 +115,14 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testExistingEnv() throws IOException {
-        String jsonString = TestUtils.loadFixture("env.json");
-        JSONObject json = JSONObject.fromObject(jsonString);
-        MockConfig config = new MockConfig();
+        final String jsonString = TestUtils.loadFixture("env.json");
+        final JSONObject json = JSONObject.fromObject(jsonString);
+        final MockConfig config = new MockConfig();
 
         // add to the env
         config.env.add(new MarathonVars("example", "test"));
         // build
-        MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
+        final MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
 
         assertEquals("bar", builder.getApp().getEnv().get("foo"));
         assertEquals("buzz", builder.getApp().getEnv().get("fizz"));
@@ -139,9 +134,9 @@ public class MarathonBuilderImplTest {
      */
     @Test
     public void testNoEnv() throws IOException {
-        String jsonString = TestUtils.loadFixture("idonly.json");
-        JSONObject json = JSONObject.fromObject(jsonString);
-        MockConfig config = new MockConfig();
+        final String jsonString = TestUtils.loadFixture("idonly.json");
+        final JSONObject json = JSONObject.fromObject(jsonString);
+        final MockConfig config = new MockConfig();
         MarathonBuilder  builder    = new MarathonBuilderImpl(config).setJson(json).build();
         assertNull("Env should be null", builder.getApp().getEnv());
 
@@ -161,7 +156,7 @@ public class MarathonBuilderImplTest {
         List<MarathonUri>   uris;
         List<MarathonLabel> labels;
         List<MarathonVars>  env;
-        long timeout;
+        long                timeout;
 
         MockConfig() {
             this.uris = new ArrayList<>();


### PR DESCRIPTION
At the moment the Jenkins-Marathon-Plugin just fires and forgets deployments. Within this PR the Marathon-Deployment-API is asked afterwards if the deployment with a given id could be finished or not in time. Otherwise the Jenkins build step will fail.
To increase testability I refactored the mighty MarathonBuilder a little and put the update part into a separate class.