### PR TITLE
Container type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Marathon Plugin for Jenkins [![Build Status](https://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=marathon-plugin-publish-master)](https://jenkins.mesosphere.com/service/jenkins/job/marathon-plugin-publish-master/)
+# Marathon Plugin for Jenkins  [![Build Status](https://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=marathon-jenkins-plugin/marathon-plugin-publish-master)](https://jenkins.mesosphere.com/service/jenkins/job/marathon-plugin-publish-master/)
 
 ## Background
 
@@ -50,10 +50,16 @@ marathon(
     forceUpdate: false,
     id: 'someid',
     docker: 'mesosphere/jenkins-dev',
+    containerType: 'DOCKER', // optional
     dockerForcePull: true)
 ```
 
 `url` is required and this still depends on a local "marathon.json" file.
+
+## Container type support
+
+The container type (MESOS, DOCKER) will be determined from the JSON template if possible, if not, it can also be defined in the plugin
+configuration or in the pipeline step call. If not defined, "DOCKER" will be used as the default value.
 
 ## License
 

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
@@ -52,6 +52,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     private       List<MarathonVars>  env;
     private       String              appid;
     private       String              docker;
+    private       String              containerType;
     private       boolean             dockerForcePull;
     private       String              filename;
     private       String              credentialsId;
@@ -195,6 +196,10 @@ public class MarathonRecorder extends Recorder implements AppConfig {
         return docker;
     }
 
+    public String getContainerType() {
+        return containerType;
+    }
+
     public boolean getDockerForcePull() {
         return dockerForcePull;
     }
@@ -229,6 +234,11 @@ public class MarathonRecorder extends Recorder implements AppConfig {
     @DataBoundSetter
     public void setDocker(@Nonnull final String docker) {
         this.docker = docker;
+    }
+
+    @DataBoundSetter
+    public void setContainerType(@Nonnull final String containerType) {
+        this.containerType = containerType;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
@@ -41,6 +41,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     private       String              appid;
     private       String              id;
     private       String              docker;
+    private       String              containerType;
     private       boolean             dockerForcePull;
     private       String              filename;
     private       String              credentialsId;
@@ -66,6 +67,11 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     @Override
     public boolean getForceUpdate() {
         return forceUpdate;
+    }
+
+    @Override
+    public String getContainerType() {
+        return this.containerType;
     }
 
     @DataBoundSetter
@@ -138,6 +144,11 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
     @DataBoundSetter
     public void setDocker(final String docker) {
         this.docker = docker;
+    }
+
+    @DataBoundSetter
+    public void setContainerType(final String containerType) {
+        this.containerType = containerType;
     }
 
     /**

--- a/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImpl.java
@@ -298,8 +298,19 @@ public class MarathonBuilderImpl extends MarathonBuilder {
             if (getApp().getContainer().getDocker() == null) {
                 getApp().getContainer().setDocker(new Docker());
             }
-
-            getApp().getContainer().setType("DOCKER");
+            String containerType = "DOCKER"; // default
+            // if it's already present in the given json template, use the container
+            // type defined there
+            if (json.containsKey("container")) {
+                JSONObject container = json.getJSONObject("container");
+                if (container.containsKey("type")) {
+                    containerType = container.getString("type");
+                }
+            } else if (config.getContainerType() != null) {
+                // if it's not, try to get one from configuration
+                containerType = config.getContainerType();
+            }
+            getApp().getContainer().setType(containerType);
             getApp().getContainer().getDocker().setImage(imageName);
             getApp().getContainer().getDocker().setForcePullImage(config.getDockerForcePull());
         }

--- a/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/interfaces/AppConfig.java
@@ -32,6 +32,13 @@ public interface AppConfig {
     boolean getForceUpdate();
 
     /**
+     * Get the configured container type.
+     *
+     * @return Container type ("MESOS" or "DOCKER")
+     */
+    String getContainerType();
+
+    /**
      * Get the configured docker image name.
      *
      * @return Docker image name

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/config.jelly
@@ -13,6 +13,13 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%Container type}" field="containerType">
+        <select name="containerType">
+            <option value="DOCKER">DOCKER</option>
+            <option value="MESOS">MESOS</option>
+        </select>
+    </f:entry>
+
         <f:advanced>
             <f:entry title="${%Definition File}" field="filename">
                 <f:textbox />

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-containerType.html
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonRecorder/help-containerType.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Set the container type used by mesos (can be MESOS for UCR or DOCKER).
+    </p>
+</div>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/config.jelly
@@ -17,6 +17,13 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%Container type}" field="containerType">
+        <select name="containerType">
+            <option value="DOCKER">DOCKER</option>
+            <option value="MESOS">MESOS</option>
+        </select>
+    </f:entry>
+
         <f:advanced>
             <f:entry title="${%Definition File}" field="filename">
                 <f:textbox/>

--- a/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/help-containerType.html
+++ b/src/main/resources/com/mesosphere/velocity/marathon/MarathonStep/help-containerType.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Set the container type used by mesos (can be MESOS for UCR or DOCKER).
+    </p>
+</div>

--- a/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/impl/MarathonBuilderImplTest.java
@@ -134,6 +134,55 @@ public class MarathonBuilderImplTest {
         assertEquals("test", builder.getApp().getEnv().get("example"));
     }
 
+
+    /**
+     * Test container type detection within template JSON
+     */
+    @Test
+    public void testSimpleContainerTypeDetection() throws IOException {
+        final String     jsonString = TestUtils.loadFixture("mesos-containertype.json");
+        final JSONObject json       = JSONObject.fromObject(jsonString);
+        final MockConfig config     = new MockConfig();
+
+        MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
+
+        assertEquals("MESOS", builder.getApp().getContainer().getType());
+    }
+
+
+    /**
+     * Test container type setup through configuration
+     */
+    @Test
+    public void testContainerTypeConfiguration() throws IOException {
+        final String     jsonString = TestUtils.loadFixture("idonly.json");
+        final JSONObject json       = JSONObject.fromObject(jsonString);
+        final MockConfig config     = new MockConfig();
+
+        config.docker = "test";
+        config.containerType = "MESOS";
+
+        MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
+
+        assertEquals("MESOS", builder.getApp().getContainer().getType());
+    }
+
+    /**
+     * Test default container type
+     */
+    @Test
+    public void testDefaultContainerType() throws IOException {
+        final String     jsonString = TestUtils.loadFixture("idonly.json");
+        final JSONObject json       = JSONObject.fromObject(jsonString);
+        final MockConfig config     = new MockConfig();
+
+        config.docker = "test";
+
+        MarathonBuilder builder = new MarathonBuilderImpl(config).setJson(json).build();
+
+        assertEquals("DOCKER", builder.getApp().getContainer().getType());
+    }
+
     /**
      * Test that an empty env section can be added to without issues.
      */
@@ -156,6 +205,7 @@ public class MarathonBuilderImplTest {
         String              appId;
         boolean             forceUpdate;
         String              docker;
+        String              containerType;
         boolean             dockerForcePull;
         String              credentialsId;
         List<MarathonUri>   uris;
@@ -176,6 +226,11 @@ public class MarathonBuilderImplTest {
         @Override
         public String getUrl() {
             return url;
+        }
+
+        @Override
+        public String getContainerType() {
+            return containerType;
         }
 
         @Override

--- a/src/test/resources/com/mesosphere/velocity/marathon/mesos-containertype.json
+++ b/src/test/resources/com/mesosphere/velocity/marathon/mesos-containertype.json
@@ -1,0 +1,170 @@
+{
+  "id": "/foo",
+  "instances": 2,
+  "cmd": "sleep 1000",
+  "cpus": 0.1,
+  "disk": 0,
+  "mem": 16,
+  "acceptedResourceRoles": [
+    "mesos_role"
+  ],
+  "args": [
+    "sleep",
+    "100"
+  ],
+  "backoffFactor": 1.15,
+  "backoffSeconds": 1,
+  "constraints": [
+    [
+      "hostname",
+      "LIKE",
+      "srv2.*"
+    ]
+  ],
+  "container": {
+    "docker": {
+      "forcePullImage": false,
+      "image": "mesosphere:marathon/latest",
+      "parameters": [
+        {
+          "key": "name",
+          "value": "kdc"
+        }
+      ],
+      "privileged": false
+    },
+    "type": "MESOS",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp",
+        "servicePort": 10019,
+        "name": "http",
+        "labels": {
+          "vip": "192.168.0.1:80"
+        }
+      }
+    ],
+    "volumes": [
+      {
+        "containerPath": "/docker_storage",
+        "hostPath": "/hdd/tools/docker/registry",
+        "mode": "RW"
+      }
+    ]
+  },
+  "networks": [
+    {
+      "mode": "container/bridge",
+      "labels": {}
+    }
+  ],
+  "dependencies": [
+    "/prod/group"
+  ],
+  "env": {
+    "XPS1": "Test",
+    "XPS2": "Rest",
+    "PASSWORD": {
+      "secret": "/db/password"
+    }
+  },
+  "executor": "",
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 300,
+      "ignoreHttp1xx": false,
+      "intervalSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 20
+    }
+  ],
+  "readinessChecks": [
+    {
+      "name": "myReadyCheck",
+      "protocol": "HTTP",
+      "path": "/v1/plan",
+      "portName": "http",
+      "intervalSeconds": 10,
+      "timeoutSeconds": 3,
+      "httpStatusCodesForReady": [
+        200
+      ],
+      "preserveLastResponse": true
+    }
+  ],
+  "labels": {
+    "owner": "zeus",
+    "note": "Away from olympus"
+  },
+  "maxLaunchDelaySeconds": 3600,
+  "ipAddress": {
+    "discovery": {
+      "ports": [
+        {
+          "number": 8080,
+          "name": "rest-endpoint",
+          "protocol": "tcp"
+        }
+      ]
+    },
+    "groups": [
+      "dev"
+    ],
+    "labels": {
+      "environment": "dev"
+    }
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "http",
+      "labels": {
+        "vip": "192.168.0.1:80"
+      }
+    },
+    {
+      "port": 31009,
+      "protocol": "tcp",
+      "labels": {
+        "VIP_0": "3.3.3.3"
+      }
+    }
+  ],
+  "requirePorts": false,
+  "upgradeStrategy": {
+    "maximumOverCapacity": 1,
+    "minimumHealthCapacity": 1
+  },
+  "fetch": [
+    {
+      "uri": "https://foo.com/setup.py"
+    },
+    {
+      "uri": "https://foo.com/archive.zip",
+      "executable": false,
+      "extract": true,
+      "cache": true,
+      "outputFile": "newname.zip"
+    }
+  ],
+  "user": "root",
+  "secrets": {
+    "secret1": {
+      "source": "/db/password"
+    },
+    "secret3": {
+      "source": "/foo2"
+    }
+  },
+  "taskKillGracePeriodSeconds": 30,
+  "residency": {
+    "relaunchEscalationTimeoutSeconds": 60,
+    "taskLostBehavior": "WAIT_FOREVER"
+  }
+}


### PR DESCRIPTION
Implements container type support as defined here:  http://mesos.apache.org/documentation/latest/container-image/

The container type is detected automatically within the JSON template, or can be defined through the plugin configuration, it's defaulted to the legacy `DOCKER` value if not defined (which was the value defined by previous versions of the plugin).